### PR TITLE
refactor: replace `cli-color` with `picocolors`

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+package-lock=false

--- a/lib/job-queue.js
+++ b/lib/job-queue.js
@@ -1,7 +1,7 @@
 'use strict';
 
 const moduleName = 'job-queue';
-const clc = require('cli-color');
+const colors = require('picocolors');
 const watt = require('gigawatts');
 const {locks} = require('xcraft-core-utils');
 const runner = require('./runnerInstance.js');
@@ -69,7 +69,7 @@ class JobQueue {
       return;
     }
 
-    const msg = `«${clc.blackBright.bold(this.name)}» waiting:${
+    const msg = `«${colors.blackBright(colors.bold(this.name))}» waiting:${
       this.waiting.size
     } running:${this.running}`;
     this.log.info(msg);
@@ -80,12 +80,12 @@ class JobQueue {
       return;
     }
 
-    const msg = `«${clc.blackBright.bold(this.name)}» ${debugMessage}`;
+    const msg = `«${colors.blackBright(colors.bold(this.name))}» ${debugMessage}`;
     this.log.dbg(msg);
   }
 
   err(ex) {
-    const msg = `«${clc.blackBright.bold(this.name)}» ${
+    const msg = `«${colors.blackBright(colors.bold(this.name))}» ${
       ex.stack || ex.message || ex
     }`;
 

--- a/lib/log.js
+++ b/lib/log.js
@@ -1,18 +1,18 @@
 'use strict';
 
 var util = require('util');
-var clc = require('cli-color');
+var colors = require('picocolors');
 var figlet = require('figlet');
 var ansiRegex = require('ansi-regex');
 
 var xUtils = require('..');
 
 var colors = {
-  verb: clc.cyanBright.bold,
-  info: clc.greenBright.bold,
-  warn: clc.yellowBright.bold,
-  err: clc.redBright.bold,
-  dbg: clc.magentaBright.bold,
+  verb: text => colors.cyanBright(colors.bold(text)),
+  info: text => colors.greenBright(colors.bold(text)),
+  warn: text => colors.yellowBright(colors.bold(text)),
+  err: text => colors.redBright(colors.bold(text)),
+  dbg: text => colors.magentaBright(colors.bold(text)),
 };
 
 var indent = 20;
@@ -47,16 +47,17 @@ exports.computeIndent = function (prefix, mod) {
 
 exports.decorate = function (mode, prefix, mod, log, maxWidth, stripBegin) {
   if (!maxWidth) {
-    maxWidth = clc.windowSize.width;
+    // https://github.com/medikoo/cli-color/blob/b9080d464c76930b3cbfb7f281999fcc26f39fb1/window-size.js#L6
+    maxWidth = process.stdout.columns || 0;
   }
 
   var len = exports.computeIndent(prefix, mod);
   var spaces = mode.length < 4 ? '  ' : ' ';
   var begin = util.format(
     '%s [%s%s] %s:%s',
-    clc.white(prefix),
-    clc.whiteBright.bold(mod),
-    new Array(len + 1).join(clc.blackBright('.')),
+    colors.white(prefix),
+    colors.whiteBright(colors.bold(mod)),
+    new Array(len + 1).join(colors.blackBright('.')),
     colors[mode](xUtils.string.capitalize(mode)),
     spaces
   );
@@ -162,16 +163,16 @@ exports.graffiti = function (text, callback) {
       const output = data.replace(/[_/\\]/g, (match) => {
         switch (match) {
           case '_': {
-            return clc.green(match);
+            return colors.green(match);
           }
           case '/': {
-            return clc.greenBright(match);
+            return colors.greenBright(match);
           }
           case '\\': {
-            return clc.blackBright(match);
+            return colors.blackBright(match);
           }
           case '|': {
-            return clc.white(match);
+            return colors.white(match);
           }
         }
       });

--- a/package.json
+++ b/package.json
@@ -21,27 +21,27 @@
   "author": "Mathieu Schroeter",
   "license": "MIT",
   "dependencies": {
+    "@npcz/magic": "^1.3.16",
+    "@zip.js/zip.js": "^2.7.45",
     "ansi-regex": "^5.0.1",
-    "cli-color": "^1.2.0",
     "escape-regexp": "0.0.1",
     "escape-string-regexp": "^1.0.5",
     "figlet": "^1.2.1",
     "fs-extra": "^9.1.0",
-    "got": "^13.0.0",
     "gigawatts": "^4.0.1",
+    "got": "^13.0.0",
     "js-yaml": "^3.9.0",
     "JSONStream": "^1.3.5",
     "linked-list": "^1.0.4",
-    "lodash": "^4.17.20",
     "locks": "^0.2.2",
-    "@npcz/magic": "^1.3.16",
+    "lodash": "^4.17.20",
+    "picocolors": "^1.1.1",
     "prop-types": "^15.7.2",
     "uuid": "^8.3.2",
     "xcraft-core-busclient": "^5.0.0",
     "xcraft-core-fs": "^2.0.0",
     "xcraft-core-log": "^2.0.0",
-    "xcraft-traverse": "^0.7.0",
-    "@zip.js/zip.js": "^2.7.45"
+    "xcraft-traverse": "^0.7.0"
   },
   "bugs": {
     "url": "https://github.com/Xcraft-Inc/xcraft-core-utils/issues"


### PR DESCRIPTION
`cli-color` -> `es5-ext` detected as a virus

https://github.com/medikoo/es5-ext/issues/186